### PR TITLE
Update gerbers_jlcpcb.kibot.yml

### DIFF
--- a/.kibot/gerbers_jlcpcb.kibot.yml
+++ b/.kibot/gerbers_jlcpcb.kibot.yml
@@ -108,7 +108,7 @@ outputs:
     dir: gerbers/jlcpcb
     options:
       variant: rotated
-      output: "%f_cpl.%x"
+      output: "%f-%i_cpl.%x"
       format: CSV
       units: millimeters
       separate_files_for_front_and_back: true


### PR DESCRIPTION
Add top/bottom to name to prevent "Asking for two separated files, but both with the same name." error.

See https://github.com/INTI-CMNB/KiBot#:~:text=Important%3A%20when%20using%20separate%20files%20you%20must%20use%20%25i%20to%20differentiate%20them

See test of the old format here: https://github.com/ModischFabrications/EasyLight_PCB/actions/runs/4028365312

And the new one with that fix here, ignoring the other error: https://github.com/ModischFabrications/EasyLight_PCB/actions/runs/4028365312